### PR TITLE
Adding an edge case to check for package.json and template version

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,8 +16,12 @@ export function isObjectEmpty(object: object) {
 }
 
 export function getCorrectZip(zip: string): string {
-  const { version } = JSON.parse(fs.readFileSync("package.json").toString());
-  return zip.replace("{version}", version);
+  if (getIsFileExists("package.json") && zip.includes("{version}")) {
+    const packageJson = JSON.parse(fs.readFileSync("package.json").toString());
+    return zip.replace("{version}", packageJson.version || "");
+  } else {
+    return zip
+  }
 }
 
 function getExtJson(zip: string) {


### PR DESCRIPTION
Hi @avi12, hope all is well! Just wanted to add some edge case handling so that web-ext-deploy can be used even if there's no package.json (i.e, when using in a ci environment where the zip is downloaded and cached separately from the source code)

Feel free to @ me if you have any question!