### PR TITLE
Added support for Edge Publish API

### DIFF
--- a/EDGE_PUBLISH_API.md
+++ b/EDGE_PUBLISH_API.md
@@ -1,0 +1,7 @@
+# How to generate Microsoft Edge Publish API credentials
+
+1. Follow the [Before you begin](https://docs.microsoft.com/en-us/microsoft-edge/extensions-chromium/publish/api/using-addons-api#before-you-begin) part.
+2. Run
+   ```powershell
+   web-ext-deploy --edge-client-id="client_id" --edge-client-secret="client_secret" --edge-access-token-url="access_token_url"
+   ```

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ Supported stores:
 
 # Core packages used
 
-- [Puppeteer](https://github.com/puppeteer/puppeteer) - for updating extensions on Firefox Add-ons / Edge Add-ons
+- [Puppeteer](https://github.com/puppeteer/puppeteer) - for updating extensions on Firefox Add-ons
   Add-ons / Opera Add-ons store.
 - [Chrome Web Store Publish API](https://developer.chrome.com/docs/webstore/using_webstore_api)
+- [Microsoft Edge Publish API](https://docs.microsoft.com/en-us/microsoft-edge/extensions-chromium/publish/api/using-addons-api)
 
 # Installing
 
@@ -49,7 +50,8 @@ pnpm i -g web-ext-deploy
 yarn global add web-ext-deploy
 ```
 
-Deployment to Chrome Web Store: [follow this guide](https://github.com/DrewML/chrome-webstore-upload/blob/master/How%20to%20generate%20Google%20API%20keys.md).
+Deployment to Chrome Web Store: [follow this guide](https://github.com/DrewML/chrome-webstore-upload/blob/master/How%20to%20generate%20Google%20API%20keys.md).  
+Deployment to Edge Add-ons Store: [follow this guide](https://github.com/avi12/web-ext-deploy/blob/main/EDGE_PUBLISH_API.md).
 
 # Usage
 
@@ -59,17 +61,17 @@ Deployment to Chrome Web Store: [follow this guide](https://github.com/DrewML/ch
 
 - Firefox: `sessionid`
 - Opera: `sessionid`, `csrftoken`
-- Edge: `.AspNet.Cookies`
 
 If you have a hard time obtaining the cookie(s), you can run:
 
 ```shell
-web-ext-deploy --get-cookies=firefox edge opera
+web-ext-deploy --get-cookies=firefox opera
 ```
 
-Note that for the Chrome Web Store, you'll use the Chrome Web Store Publish API.
+Note that for the Chrome Web Store, you'll use the Chrome Web Store Publish API.  
+As for the Edge Add-ons Store, you'll use the Microsoft Edge Publish API.
 
-## 2. Decide how to access the info
+## 2. Decide how to access the data & credentials
 
 - [`.env` files method](#env-files-method)
 - [CLI arguments method](#cli-arguments-method)
@@ -103,6 +105,7 @@ web-ext-deploy --env
 - `--firefox-dev-changelog` string?  
   If specified and `firefox.env` exists, it will be used to provide changelog for the Firefox Add-ons reviewers.  
   New lines (`\n`) are supported.
+
 - `--edge-dev-changelog` string?  
   If specified and `edge.env` exists, it will be used to provide changelog for the Edge Add-ons reviewers.  
   New lines (`\n`) are supported.
@@ -126,10 +129,9 @@ web-ext-deploy --env
 
 - Edge Add-ons store:
 
-  - `EXT_ID` - Get it from `https://partner.microsoft.com/en-us/dashboard/microsoftedge/EXT_ID`
+  - `CLIENT_ID`, `CLIENT_SECRET`, `ACCESS_TOKEN_URL`, `ACCESS_TOKEN`, `TOKEN_TYPE` - follow [this guide](https://github.com/avi12/web-ext-deploy/blob/main/EDGE_PUBLISH_API.md)
+  - `PRODUCT_ID` - Get it from `https://partner.microsoft.com/en-us/dashboard/microsoftedge/PRODUCT_ID`
   - `ZIP` - You can use `{version}`
-  - Due to the way the Edge dashboard works, when an extension is being reviewed or its review has just been canceled, it will take about a minute until a cancellation will cause its state to change from "In review" to "In draft", after which the new version can be submitted.  
-    Therefore, expect for longer wait times if you run the tool on an extension you had just published/canceled.
 
 - Opera Add-ons store:
   - `PACKAGE_ID` - Get it from `https://addons.opera.com/developer/package/PACKAGE_ID`
@@ -165,9 +167,13 @@ EXT_ID="ExtensionID"
 #### `edge.env`
 
 ```dotenv
-cookie=".AspNet.Cookies_value"
+CLIENT_ID="ClientID"
+CLIENT_SECRET="ClientSecret"
+ACCESS_TOKEN_URL="AccessTokenURL"
+ACCESS_TOKEN="AccessToken"
+TOKEN_TYPE="TokenType"
 ZIP="dist/some-zip-v{version}.zip"
-EXT_ID="ExtensionID"
+PRODUCT_ID="ProductID"
 ```
 
 #### `opera.env`
@@ -264,10 +270,16 @@ web-ext-deploy --firefox-ext-id="ExtensionID" --firefox-sessionid="sessionid_val
 
 #### Edge Add-ons CLI
 
-- `--edge-ext-id` string  
-  The extension ID from the Edge Add-ons Dashboard, e.g. `https://partner.microsoft.com/en-us/dashboard/microsoftedge/EXT_ID`
-- `--edge-cookie` string  
-  The value of the cookie `.AspNet.Cookies`, which will be used to log in to the publisher's account.
+- `--edge-product-id` string  
+  The product ID from the Edge Add-ons Dashboard, e.g. `https://partner.microsoft.com/en-us/dashboard/microsoftedge/EXT_ID`
+- `--edge-client-id` string  
+  The client ID.
+- `--edge-client-secret` string  
+  The client secret.
+- `--edge-access-token-url` string  
+  The access token URL.
+- `--edge-access-token` string  
+  The access token.
 - `--edge-zip` string  
   The path to the ZIP from the root.  
   You can use `{version}` in the ZIP filename, which will be replaced by the `version` entry in `package.json`
@@ -275,10 +287,12 @@ web-ext-deploy --firefox-ext-id="ExtensionID" --firefox-sessionid="sessionid_val
   The technical changes made in this version, which will be seen by the Edge Add-ons reviewers.  
   You can use `\n` for new lines.
 
+To get your `--edge-access-token`, `--edge-client-id`, `--edge-client-secret`, `--edge-access-token-url`, follow [this guide](https://github.com/avi12/web-ext-deploy/blob/main/EDGE_PUBLISH_API.md).
+
 Example:
 
 ```shell
-web-ext-deploy --edge-ext-id="ExtensionID" --edge-cookie=".AspNet.Cookies value" --edge-zip="dist/some-zip-v{version}.zip" --edge-dev-changelog="Changelog for reviewers\nWith line breaks"
+web-ext-deploy --edge-product-id="ProductID" --edge-access-token="accessToken value" --edge-client-id="clientId" --edge-client-secret="clientSecret" --edge-access-token-url="accessTokenUrl" --edge-zip="dist/some-zip-v{version}.zip" --edge-dev-changelog="Changelog for reviewers\nWith line breaks"
 ```
 
 **Note:**  
@@ -323,14 +337,14 @@ web-ext-deploy --opera-package-id=123456 --opera-sessionid="sessionid_value" --o
 
 <!-- prettier-ignore -->
 ```ts
-import { deployChrome, deployFirefox, deployEdge, deployOpera } from "web-ext-deploy";
+import { deployChrome, deployFirefox, deployEdgePublishApi, deployOpera } from "web-ext-deploy";
 ```
 
 ### CommonJS
 
 <!-- prettier-ignore -->
 ```js
-const { deployChrome, deployFirefox, deployEdge, deployOpera } = require("web-ext-deploy");
+const { deployChrome, deployFirefox, deployEdgePublishApi, deployOpera } = require("web-ext-deploy");
 ```
 
 ### Node.js API
@@ -360,9 +374,9 @@ const { deployChrome, deployFirefox, deployEdge, deployOpera } = require("web-ex
   If `true`, it will be logged to the console when the uploading has begun.
 
 To get your `refreshToken`, `clientId`, and `clientSecret`, follow [this guide](https://github.com/DrewML/chrome-webstore-upload/blob/master/How%20to%20generate%20Google%20API%20keys.md).  
- Returns `Promise<true>` or throws an exception.
+Returns `Promise<true>` or throws an exception.
 
-#### Firefox Add-ons API
+#### Firefox Publish API
 
 `deployFirefox` object  
  Options:
@@ -395,20 +409,25 @@ web-ext-deploy --get-cookies=firefox
 
 Returns `Promise<true>` or throws an exception.
 
-#### Edge Add-ons API
+#### Edge Publish API
 
-`deployEdge` object  
+`deployEdgePublishApi` object  
  Options:
 
-- `extId` string  
-  Get it from `https://partner.microsoft.com/en-us/dashboard/microsoftedge/EXT_ID`
-- `cookie` string  
-  The value of the cookie `.AspNet.Cookies`, which will be used to log in to the publisher's account.  
-  If you have a hard time obtaining it, you can run:
+- `productId` string  
+  Get it from `https://partner.microsoft.com/en-us/dashboard/microsoftedge/PRODUCT_ID`
 
-```shell
-web-ext-deploy --get-cookies=edge
-```
+- `accessToken` string  
+  The access token.
+
+- `clientId` string  
+  The client ID.
+
+- `clientSecret` string  
+  The client secret.
+
+- `accessTokenUrl` string  
+  The access token URL.
 
 - `zip` string  
   The relative path from the root to the ZIP.  
@@ -419,13 +438,14 @@ web-ext-deploy --get-cookies=edge
 - `verbose` boolean?  
   If `true`, every step of uploading to the Edge Add-ons will be logged to the console.
 
+To get your `accessToken` and `tokenType`, follow [this guide](https://github.com/avi12/web-ext-deploy/blob/main/EDGE_PUBLISH_API.md).  
 Returns `Promise<true>` or throws an exception.
 
 **Note:**  
 Due to the way the Edge dashboard works, when an extension is being reviewed or its review has just been canceled, it will take about a minute until a cancellation will cause its state to change from "In review" to "In draft", after which the new version can be submitted.  
 Therefore, expect for longer wait times if you run the tool on an extension you had just published/canceled.
 
-#### Opera Add-ons API
+#### Opera Publish API
 
 `deployOpera` object  
  Options:
@@ -469,7 +489,7 @@ Examples:
 
 <!-- prettier-ignore -->
 ```ts
-import { deployChrome, deployFirefox, deployEdge, deployOpera } from "web-ext-deploy";
+import { deployChrome, deployFirefox, deployEdgePublishApi, deployOpera } from "web-ext-deploy";
 
 deployChrome({
   extId: "EXT_ID",
@@ -490,9 +510,12 @@ deployFirefox({
   verbose: false
 }).catch(console.error);
 
-deployEdge({
-  extId: "EXT_ID",
-  cookie: ".AspNet.Cookies value",
+deployEdgePublishApi({
+  productId: "PRODUCT_ID",
+  clientId: "clientId",
+  clientSecret: "clientSecret",
+  accessTokenUrl: "accessTokenUrl",
+  accessToken: "accessToken",
   zip: "dist/some-zip-v{version}.zip",
   devChangelog: "Changes for reviewers",
   verbose: false

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ web-ext-deploy --env
 
 - Edge Add-ons store:
 
-  - `CLIENT_ID`, `CLIENT_SECRET`, `ACCESS_TOKEN_URL`, `ACCESS_TOKEN`, `TOKEN_TYPE` - follow [this guide](https://github.com/avi12/web-ext-deploy/blob/main/EDGE_PUBLISH_API.md)
+  - `CLIENT_ID`, `CLIENT_SECRET`, `ACCESS_TOKEN_URL`, `ACCESS_TOKEN` - follow [this guide](https://github.com/avi12/web-ext-deploy/blob/main/EDGE_PUBLISH_API.md)
   - `PRODUCT_ID` - Get it from `https://partner.microsoft.com/en-us/dashboard/microsoftedge/PRODUCT_ID`
   - `ZIP` - You can use `{version}`
 
@@ -171,7 +171,6 @@ CLIENT_ID="ClientID"
 CLIENT_SECRET="ClientSecret"
 ACCESS_TOKEN_URL="AccessTokenURL"
 ACCESS_TOKEN="AccessToken"
-TOKEN_TYPE="TokenType"
 ZIP="dist/some-zip-v{version}.zip"
 PRODUCT_ID="ProductID"
 ```
@@ -438,7 +437,7 @@ Returns `Promise<true>` or throws an exception.
 - `verbose` boolean?  
   If `true`, every step of uploading to the Edge Add-ons will be logged to the console.
 
-To get your `accessToken` and `tokenType`, follow [this guide](https://github.com/avi12/web-ext-deploy/blob/main/EDGE_PUBLISH_API.md).  
+To get your `accessToken`, `clientId`, `clientSecret`, and `accessTokenUrl`, follow [this guide](https://github.com/avi12/web-ext-deploy/blob/main/EDGE_PUBLISH_API.md).  
 Returns `Promise<true>` or throws an exception.
 
 **Note:**  

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
+    "axios": "^0.27.2",
     "camel-case": "^4.1.2",
     "chrome-webstore-upload": "0.4.4",
     "compare-versions": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-ext-deploy",
-  "version": "0.7.16",
+  "version": "0.8.0",
   "description": "A tool for deploying WebExtensions to multiple stores.",
   "main": "./dist/index.js",
   "module": "./dist-esm/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,10 +1,11 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@types/puppeteer': ^5.4.5
   '@types/yargs': ^17.0.9
   '@typescript-eslint/eslint-plugin': ^5.13.0
   '@typescript-eslint/parser': ^5.13.0
+  axios: ^0.27.2
   camel-case: ^4.1.2
   chrome-webstore-upload: 0.4.4
   compare-versions: ^4.1.3
@@ -22,6 +23,7 @@ specifiers:
   zip-local: ^0.3.5
 
 dependencies:
+  axios: 0.27.2
   camel-case: 4.1.2
   chrome-webstore-upload: 0.4.4
   compare-versions: 4.1.3
@@ -34,8 +36,8 @@ dependencies:
 devDependencies:
   '@types/puppeteer': 5.4.5
   '@types/yargs': 17.0.9
-  '@typescript-eslint/eslint-plugin': 5.13.0_33fffc354ccfa91fbe7d1677b9395a0a
-  '@typescript-eslint/parser': 5.13.0_eslint@8.10.0+typescript@4.6.2
+  '@typescript-eslint/eslint-plugin': 5.13.0_gp77ynkmz6ur7pt5cz33sok2bi
+  '@typescript-eslint/parser': 5.13.0_pzezdwkd5bvjkx2hshexc25sxq
   eslint: 8.10.0
   eslint-config-prettier: 8.5.0_eslint@8.10.0
   nodemon: 2.0.15
@@ -172,7 +174,6 @@ packages:
     resolution: {integrity: sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==}
     dependencies:
       '@types/node': 17.0.21
-    dev: false
 
   /@types/node/17.0.21:
     resolution: {integrity: sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==}
@@ -187,7 +188,6 @@ packages:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
       '@types/node': 17.0.21
-    dev: false
 
   /@types/yargs-parser/21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
@@ -207,7 +207,7 @@ packages:
     dev: false
     optional: true
 
-  /@typescript-eslint/eslint-plugin/5.13.0_33fffc354ccfa91fbe7d1677b9395a0a:
+  /@typescript-eslint/eslint-plugin/5.13.0_gp77ynkmz6ur7pt5cz33sok2bi:
     resolution: {integrity: sha512-vLktb2Uec81fxm/cfz2Hd6QaWOs8qdmVAZXLdOBX6JFJDhf6oDZpMzZ4/LZ6SFM/5DgDcxIMIvy3F+O9yZBuiQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -218,10 +218,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.13.0_eslint@8.10.0+typescript@4.6.2
+      '@typescript-eslint/parser': 5.13.0_pzezdwkd5bvjkx2hshexc25sxq
       '@typescript-eslint/scope-manager': 5.13.0
-      '@typescript-eslint/type-utils': 5.13.0_eslint@8.10.0+typescript@4.6.2
-      '@typescript-eslint/utils': 5.13.0_eslint@8.10.0+typescript@4.6.2
+      '@typescript-eslint/type-utils': 5.13.0_pzezdwkd5bvjkx2hshexc25sxq
+      '@typescript-eslint/utils': 5.13.0_pzezdwkd5bvjkx2hshexc25sxq
       debug: 4.3.3
       eslint: 8.10.0
       functional-red-black-tree: 1.0.1
@@ -234,7 +234,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.13.0_eslint@8.10.0+typescript@4.6.2:
+  /@typescript-eslint/parser/5.13.0_pzezdwkd5bvjkx2hshexc25sxq:
     resolution: {integrity: sha512-GdrU4GvBE29tm2RqWOM0P5QfCtgCyN4hXICj/X9ibKED16136l9ZpoJvCL5pSKtmJzA+NRDzQ312wWMejCVVfg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -262,7 +262,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.13.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.13.0_eslint@8.10.0+typescript@4.6.2:
+  /@typescript-eslint/type-utils/5.13.0_pzezdwkd5bvjkx2hshexc25sxq:
     resolution: {integrity: sha512-/nz7qFizaBM1SuqAKb7GLkcNn2buRdDgZraXlkhz+vUGiN1NZ9LzkA595tHHeduAiS2MsHqMNhE2zNzGdw43Yg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -272,7 +272,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.13.0_eslint@8.10.0+typescript@4.6.2
+      '@typescript-eslint/utils': 5.13.0_pzezdwkd5bvjkx2hshexc25sxq
       debug: 4.3.3
       eslint: 8.10.0
       tsutils: 3.21.0_typescript@4.6.2
@@ -307,7 +307,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.13.0_eslint@8.10.0+typescript@4.6.2:
+  /@typescript-eslint/utils/5.13.0_pzezdwkd5bvjkx2hshexc25sxq:
     resolution: {integrity: sha512-+9oHlPWYNl6AwwoEt5TQryEHwiKRVjz7Vk6kaBeD3/kwHE5YqTGHtm/JZY8Bo9ITOeKutFaXnBlMgSATMJALUQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -413,6 +413,19 @@ packages:
 
   /async/1.5.2:
     resolution: {integrity: sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=}
+    dev: false
+
+  /asynckit/0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: false
+
+  /axios/0.27.2:
+    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
+    dependencies:
+      follow-redirects: 1.15.0
+      form-data: 4.0.0
+    transitivePeerDependencies:
+      - debug
     dev: false
 
   /balanced-match/1.0.2:
@@ -586,6 +599,13 @@ packages:
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  /combined-stream/1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      delayed-stream: 1.0.0
+    dev: false
+
   /compare-versions/4.1.3:
     resolution: {integrity: sha512-WQfnbDcrYnGr55UwbxKiQKASnTtNnaAWVi8jZyy8NTpVAXWACSne8lMD1iaIo9AiU6mnuLvSVshCzewVuWxHUg==}
     dev: false
@@ -631,10 +651,16 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /debug/3.2.7:
+  /debug/3.2.7_supports-color@5.5.0:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
+      supports-color: 5.5.0
     dev: true
 
   /debug/4.3.3:
@@ -678,6 +704,11 @@ packages:
   /defer-to-connect/2.0.1:
     resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
     engines: {node: '>=10'}
+    dev: false
+
+  /delayed-stream/1.0.0:
+    resolution: {integrity: sha1-3zrhmayt+31ECqrgsp4icrJOxhk=}
+    engines: {node: '>=0.4.0'}
     dev: false
 
   /devtools-protocol/0.0.960912:
@@ -952,6 +983,25 @@ packages:
     resolution: {integrity: sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==}
     dev: true
 
+  /follow-redirects/1.15.0:
+    resolution: {integrity: sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
+
+  /form-data/4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: false
+
   /fs-constants/1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
     dev: false
@@ -1062,6 +1112,8 @@ packages:
     dependencies:
       '@sindresorhus/is': 0.14.0
       '@szmarczak/http-timer': 1.1.2
+      '@types/keyv': 3.1.1
+      '@types/responselike': 1.0.0
       cacheable-request: 6.1.0
       decompress-response: 3.3.0
       duplexer3: 0.1.4
@@ -1349,6 +1401,18 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /mime-db/1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /mime-types/2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.52.0
+    dev: false
+
   /mimic-response/1.0.1:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
     engines: {node: '>=4'}
@@ -1408,7 +1472,7 @@ packages:
     requiresBuild: true
     dependencies:
       chokidar: 3.5.3
-      debug: 3.2.7
+      debug: 3.2.7_supports-color@5.5.0
       ignore-by-default: 1.0.1
       minimatch: 3.1.2
       pstree.remy: 1.1.8

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,44 +4,55 @@ import dotenv from "dotenv";
 import { camelCase } from "camel-case";
 import { ChromeOptions } from "./stores/chrome/chrome-input";
 import { FirefoxOptions } from "./stores/firefox/firefox-input";
-import { EdgeOptions } from "./stores/edge/edge-input";
 import { OperaOptions } from "./stores/opera/opera-input";
 import { getSignInCookie } from "./get-sign-in-cookie";
+import { EdgeOptionsPublishApi } from "./stores/edge/new/edge-input";
+import { Stores } from "./types";
+import { EdgeOptions } from "./stores/edge/old/edge-input-old";
 
-const argv = yargs(process.argv.slice(2)).options({
-  env: { type: "boolean" },
-  extId: { type: "string" },
-  zip: { type: "string" },
-  verbose: { type: "boolean" },
-  // chrome
-  chromeExtId: { type: "string" },
-  chromeRefreshToken: { type: "string" },
-  chromeClientId: { type: "string" },
-  chromeClientSecret: { type: "string" },
-  chromeZip: { type: "string" },
-  // firefox
-  firefoxSessionid: { type: "string" },
-  firefoxExtId: { type: "string" },
-  firefoxZip: { type: "string" },
-  firefoxZipSource: { type: "string" },
-  firefoxChangelog: { type: "string" },
-  firefoxDevChangelog: { type: "string" },
-  // edge
-  edgeCookie: { type: "string" },
-  edgeExtId: { type: "string" },
-  edgeZip: { type: "string" },
-  edgeDevChangelog: { type: "string" },
-  // opera
-  operaSessionid: { type: "string" },
-  operaCsrftoken: { type: "string" },
-  operaExtId: { type: "string" },
-  operaZip: { type: "string" },
-  operaChangelog: { type: "string" }
-}).parseSync();
+const argv = yargs(process.argv.slice(2))
+  .options({
+    env: { type: "boolean" },
+    extId: { type: "string" },
+    zip: { type: "string" },
+    verbose: { type: "boolean" },
+    // chrome
+    chromeExtId: { type: "string" },
+    chromeRefreshToken: { type: "string" },
+    chromeClientId: { type: "string" },
+    chromeClientSecret: { type: "string" },
+    chromeZip: { type: "string" },
+    // firefox
+    firefoxSessionid: { type: "string" },
+    firefoxExtId: { type: "string" },
+    firefoxZip: { type: "string" },
+    firefoxZipSource: { type: "string" },
+    firefoxChangelog: { type: "string" },
+    firefoxDevChangelog: { type: "string" },
+    // edge
+    /** @deprecated Use an access token, client ID, client secret, and access token URL instead */
+    edgeCookie: { type: "string" },
+    /** @deprecated Use product ID instead */
+    edgeExtId: { type: "string" },
+    edgeAccessToken: { type: "string" },
+    edgeClientId: { type: "string" },
+    edgeClientSecret: { type: "string" },
+    edgeAccessTokenUrl: { type: "string" },
+    edgeProductId: { type: "string" },
+    edgeZip: { type: "string" },
+    edgeDevChangelog: { type: "string" },
+    // opera
+    operaSessionid: { type: "string" },
+    operaCsrftoken: { type: "string" },
+    operaExtId: { type: "string" },
+    operaZip: { type: "string" },
+    operaChangelog: { type: "string" }
+  })
+  .parseSync();
 
 function getJsons(isUseEnv?: boolean): { [p: string]: any } {
   if (isUseEnv) {
-    return gStores.reduce((stores: { [s: string]: unknown }, store: string) => {
+    return Stores.reduce((stores: { [s: string]: unknown }, store: string) => {
       const { parsed = {} } = dotenv.config({ path: `${store}.env` });
       if (!isObjectEmpty(parsed)) {
         const yargsStoreArgs = getJsons(false);
@@ -66,17 +77,14 @@ function getJsons(isUseEnv?: boolean): { [p: string]: any } {
     return Object.fromEntries(entries);
   };
 
-  return gStores.reduce(
-    (stores: { [s: string]: string | number }, store: string) => {
-      const jsonStore = getFlagsArguments(argv, store);
-      if (!isObjectEmpty(jsonStore)) {
-        // @ts-ignore
-        stores[store] = jsonStore;
-      }
-      return stores;
-    },
-    {}
-  );
+  return Stores.reduce((stores, store: string) => {
+    const jsonStore = getFlagsArguments(argv, store);
+    if (!isObjectEmpty(jsonStore)) {
+      stores[store] = jsonStore;
+    }
+    return stores;
+    // eslint-disable-next-line no-unused-vars
+  }, {} as { [store in typeof Stores[number]]: unknown });
 }
 
 function jsonCamelCased(jsonStores: { [s: string]: string | number }) {
@@ -88,24 +96,25 @@ function jsonCamelCased(jsonStores: { [s: string]: string | number }) {
       camelCase(key),
       value
     ]);
-
     return [store, Object.fromEntries(entriesMapped)];
   });
 
   return Object.fromEntries(entriesWithCamelCasedKeys);
 }
 
-interface StoreObjects {
-  chrome?: ChromeOptions;
-  firefox?: FirefoxOptions;
-  edge?: EdgeOptions;
-  opera?: OperaOptions;
-}
+const StoreObjects = {
+  chrome: {} as ChromeOptions,
+  firefox: {} as FirefoxOptions,
+  edge: argv.edgeAccessToken
+    ? ({} as EdgeOptionsPublishApi)
+    : ({} as EdgeOptions),
+  opera: {} as OperaOptions
+} as const;
 
 /**
  * Used for fallbacks, e.g. `--zip="some-ext.zip" --chrome-zip="chrome-ext.zip" --firefox-ext-id="EXT_ID" --edge-ext-id="EXT_ID"`<br>So the ZIP of Firefox and Edge will be `some-ext.zip`
  */
-function fillMissing(jsonStoresRaw: StoreObjects): StoreObjects {
+function fillMissing(jsonStoresRaw: typeof StoreObjects): typeof StoreObjects {
   const jsonStores = { ...jsonStoresRaw };
   const storeArgsMissing = ["zip", "devChangelog", "verbose"];
 
@@ -123,9 +132,7 @@ function fillMissing(jsonStoresRaw: StoreObjects): StoreObjects {
   return jsonStores;
 }
 
-const gStores = ["chrome", "firefox", "edge", "opera"];
-
-export function getJsonStoresFromCli(): StoreObjects {
+export function getJsonStoresFromCli(): typeof StoreObjects {
   const jsonStoresRaw = jsonCamelCased(getJsons(argv.env));
   if (isObjectEmpty(jsonStoresRaw)) {
     throw new Error(
@@ -136,6 +143,6 @@ export function getJsonStoresFromCli(): StoreObjects {
   return fillMissing(jsonStoresRaw);
 }
 
-export async function getCookies(siteNames: string[]) {
+export async function getCookies(siteNames: string[]): Promise<void> {
   return getSignInCookie(siteNames);
 }

--- a/src/get-edge-publish-api-access-token.ts
+++ b/src/get-edge-publish-api-access-token.ts
@@ -1,0 +1,98 @@
+import axios from "axios";
+import { createGitIgnoreIfNeeded, headersToEnv } from "./utils";
+import dotenv from "dotenv";
+import fs from "fs";
+
+type EdgePublishApi = {
+  clientId: string;
+  clientSecret: string;
+  accessTokenUrl: string;
+};
+
+function getUrlSearchParams(credentials: object): string {
+  return new URLSearchParams(Object.entries(credentials)).toString();
+}
+
+async function getData({
+  clientId,
+  clientSecret,
+  accessTokenUrl
+}: EdgePublishApi): Promise<{
+  access_token?: string;
+  expires_in?: number;
+  error_description?: string;
+}> {
+  return axios
+    .post(
+      accessTokenUrl,
+      getUrlSearchParams({
+        grant_type: "client_credentials",
+        scope: "https://api.addons.microsoftedge.microsoft.com/.default",
+        client_id: clientId,
+        client_secret: clientSecret
+      }),
+      {
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded"
+        }
+      }
+    )
+    .then(res => res.data)
+    .catch(
+      e =>
+        e.response.data || {
+          error_description:
+            "The client ID, client secret and/or the access token URL are in an invalid format"
+        }
+    );
+}
+
+export function appendToEdgeEnv(data: object): void {
+  const filename = "./edge.env";
+  const { parsed: envCurrent = {} } = dotenv.config({ path: filename });
+  delete envCurrent.cookie;
+  const envAccessToken = dotenv.parse(headersToEnv(data));
+  const envNew = { ...envCurrent, ...envAccessToken };
+  fs.writeFileSync(filename, headersToEnv(envNew));
+}
+
+export async function getEdgePublishApiAccessToken({
+  clientId,
+  clientSecret,
+  accessTokenUrl
+}: EdgePublishApi): Promise<{ accessToken: string; }> {
+  return new Promise(async (resolve, reject) => {
+    const { access_token, expires_in, error_description } =
+      await getData({
+        clientId,
+        clientSecret,
+        accessTokenUrl
+      });
+
+    if (expires_in <= 20) {
+      reject(
+        "Error Edge: The client ID, client secret and/or access token URL have expired. Retrieve the new ones: https://partner.microsoft.com/en-us/dashboard/microsoftedge/publishapi"
+      );
+      return;
+    }
+
+    if (error_description) {
+      reject(`Error Edge: ${error_description}`);
+      return;
+    }
+
+    appendToEdgeEnv({
+      ACCESS_TOKEN: access_token,
+      CLIENT_ID: clientId,
+      CLIENT_SECRET: clientSecret,
+      ACCESS_TOKEN_URL: accessTokenUrl
+    });
+
+    createGitIgnoreIfNeeded(["edge"]);
+
+    console.log(
+      "Info Edge: Saved the Edge Publish API's client ID, client secret, access token, and access token URL to edge.env"
+    );
+    resolve({ accessToken: access_token });
+  });
+}

--- a/src/get-sign-in-cookie.ts
+++ b/src/get-sign-in-cookie.ts
@@ -1,6 +1,7 @@
 import puppeteer, { Page } from "puppeteer";
 import fs from "fs";
 import dotenv from "dotenv";
+import { createGitIgnoreIfNeeded, headersToEnv } from "./utils";
 
 function getFilename(site) {
   return `./${site}.env`;
@@ -127,12 +128,6 @@ const siteFuncs = {
   edge: saveEdgeHeaders
 };
 
-function headersToEnv(headersTotal: object) {
-  return Object.entries(headersTotal)
-    .map(([header, value]) => `${header}="${value}"`)
-    .join("\n");
-}
-
 function appendToEnv(filename: string, headers: string) {
   const { parsed: envCurrent = {} } = dotenv.config({ path: filename });
   const envHeaders = dotenv.parse(headers);
@@ -142,26 +137,6 @@ function appendToEnv(filename: string, headers: string) {
 
 function getInvalidSIte(siteNames: string[]) {
   return siteNames.find(site => !siteFuncs[site]);
-}
-
-function createGitIgnoreIfNeeded(stores: string[]) {
-  const filename = ".gitignore";
-  if (!fs.existsSync(filename)) {
-    fs.writeFileSync(filename, "*.env");
-    return;
-  }
-
-  const gitIgnoreCurrent = fs.readFileSync(filename).toString();
-  if (gitIgnoreCurrent.includes(".env")) {
-    if (gitIgnoreCurrent.includes("*.env")) {
-      return;
-    }
-
-    fs.appendFileSync(filename, stores.map(store => `${store}.env`).join("\n"));
-    return;
-  }
-
-  fs.appendFileSync(filename, "*.env");
 }
 
 export async function getSignInCookie(siteNames: string[]) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,68 @@
 #!/usr/bin/env node
 import yargs from "yargs/yargs";
 import { getCookies, getJsonStoresFromCli } from "./cli";
-import { ChromeOptions, prepareToDeployChrome } from "./stores/chrome/chrome-input";
-import { FirefoxOptions, prepareToDeployFirefox } from "./stores/firefox/firefox-input";
-import { EdgeOptions, prepareToDeployEdge } from "./stores/edge/edge-input";
+import {
+  ChromeOptions,
+  prepareToDeployChrome
+} from "./stores/chrome/chrome-input";
+import {
+  FirefoxOptions,
+  prepareToDeployFirefox
+} from "./stores/firefox/firefox-input";
+import {
+  EdgeOptions,
+  prepareToDeployEdge
+} from "./stores/edge/old/edge-input-old";
 import { OperaOptions, prepareToDeployOpera } from "./stores/opera/opera-input";
+import { getEdgePublishApiAccessToken } from "./get-edge-publish-api-access-token";
+import {
+  EdgeOptionsPublishApi,
+  prepareToDeployEdgePublishApi
+} from "./stores/edge/new/edge-input";
+import { Stores } from "./types";
 
 const isUseCli = Boolean(
   process.argv[1].match(/web-ext-deploy[\\/](?:dist|src)[\\/]index\.(?:ts|js)$/)
 );
 
-const argv = yargs(process.argv.slice(2)).options({
-  env: { type: "boolean", default: false },
-  getCookies: { type: "array" },
-  firefoxChangelog: { type: "string" },
-  firefoxDevChangelog: { type: "string" },
-  edgeDevChangelog: { type: "string" },
-  operaChangelog: { type: "string" },
-  verbose: { type: "boolean" }
-}).parseSync();
+const argv = yargs(process.argv.slice(2))
+  .options({
+    env: { type: "boolean", default: false },
+    getCookies: { type: "array" },
+    firefoxChangelog: { type: "string" },
+    firefoxDevChangelog: { type: "string" },
+    edgeDevChangelog: { type: "string" },
+    operaChangelog: { type: "string" },
+    verbose: { type: "boolean" },
+    // Edge Publish API parameters
+    edgeClientId: { type: "string" },
+    edgeClientSecret: { type: "string" },
+    edgeAccessTokenUrl: { type: "string" }
+  })
+  .parseSync();
 
-async function initCli() {
+function getIsIntendingToCreateEdgeCredentials() {
+  return argv.edgeClientId || argv.edgeClientSecret || argv.edgeAccessTokenUrl;
+}
+
+function checkIfIntendingToCreateEdgeCredentials(): boolean {
+  if (getIsIntendingToCreateEdgeCredentials()) {
+    const isRetrievable = Boolean(
+      argv.edgeClientId && argv.edgeClientSecret && argv.edgeAccessTokenUrl
+    );
+    if (!isRetrievable) {
+      throw new Error(
+        `It appears you're trying to create an Edge Publish API access token, but you are missing some arguments.
+To do so, make sure you have all of the following: --edge-client-id, --edge-client-secret, --edge-access-token-url`
+      );
+    }
+    return isRetrievable;
+  }
+
+  return false;
+}
+
+async function initCli(): Promise<void> {
   if (!isUseCli) {
     return;
   }
@@ -31,15 +73,30 @@ async function initCli() {
     return;
   }
 
-  const storeFuncs = {
-    chrome: deployChrome,
-    firefox: deployFirefox,
-    edge: deployEdge,
-    opera: deployOpera
-  };
+  if (checkIfIntendingToCreateEdgeCredentials()) {
+    await getEdgePublishApiAccessToken({
+      clientId: argv.edgeClientId,
+      clientSecret: argv.edgeClientSecret,
+      accessTokenUrl: argv.edgeAccessTokenUrl
+    });
+    process.exit();
+    return;
+  }
 
   const storeJsons = getJsonStoresFromCli();
   const storeEntries = Object.entries(storeJsons);
+
+  const storeFuncs: {
+    // eslint-disable-next-line no-unused-vars
+    [store in typeof Stores[number]]: (deploy) => Promise<boolean>;
+  } = {
+    chrome: deployChrome,
+    firefox: deployFirefox,
+    edge: (<EdgeOptionsPublishApi>storeJsons.edge).accessToken
+      ? deployEdgePublishApi
+      : deployEdge,
+    opera: deployOpera
+  };
   const promises = storeEntries.map(([store, json]) => storeFuncs[store](json));
   try {
     await Promise.all(promises);
@@ -64,11 +121,23 @@ export async function deployFirefox(options: FirefoxOptions): Promise<boolean> {
   return prepareToDeployFirefox(options);
 }
 
+/**
+ * @deprecated Use `deployEdgePublishApi` instead
+ */
 export async function deployEdge(options: EdgeOptions): Promise<boolean> {
   if (argv.edgeDevChangelog) {
     options.devChangelog = argv.edgeDevChangelog;
   }
   return prepareToDeployEdge(options);
+}
+
+export async function deployEdgePublishApi(
+  options: EdgeOptionsPublishApi
+): Promise<boolean> {
+  if (argv.edgeDevChangelog) {
+    options.devChangelog = argv.edgeDevChangelog;
+  }
+  return prepareToDeployEdgePublishApi(options);
 }
 
 export async function deployOpera(options: OperaOptions): Promise<boolean> {

--- a/src/stores/edge/new/edge-deploy.ts
+++ b/src/stores/edge/new/edge-deploy.ts
@@ -1,0 +1,297 @@
+import { EdgeOptionsPublishApi } from "./edge-input";
+import axios, { AxiosResponse } from "axios";
+import fs from "fs";
+import {
+  getExtInfo,
+  getVerboseMessage,
+  logSuccessfullyPublished
+} from "../../../utils";
+import { getEdgePublishApiAccessToken } from "../../../get-edge-publish-api-access-token";
+
+const store = "Edge";
+const baseUrl = `https://api.addons.microsoftedge.microsoft.com/v1`;
+const STATUS_ACCEPTED = 202;
+
+function getBaseHeaders({
+  accessToken,
+}: {
+  accessToken: string;
+}): {
+  Authorization: string;
+} {
+  return {
+    Authorization: `Bearer ${accessToken}`
+  };
+}
+
+async function getUploadStatus({
+  accessToken,
+  productID,
+  operationID
+}: {
+  accessToken: string;
+  productID: string;
+  operationID: string;
+}): Promise<AxiosResponse> {
+  return axios(
+    `${baseUrl}/products/${productID}/submissions/draft/package/operations/${operationID}`,
+    {
+      headers: getBaseHeaders({ accessToken })
+    }
+  );
+}
+
+function getErrorMessage({
+  zip,
+  error,
+  actionName
+}: {
+  zip: string;
+  error: number | string;
+  actionName: string;
+}): string {
+  return getVerboseMessage({
+    store,
+    prefix: "Error",
+    message: `Failed to ${actionName} ${getExtInfo(zip, "name")}: ${error}`
+  });
+}
+
+async function upload({
+  accessToken,
+  zip,
+  productId
+}: {
+  accessToken: string;
+  zip: string;
+  productId: string;
+}): Promise<{ location?: string; error?: string }> {
+  return axios
+    .post(
+      `${baseUrl}/products/${productId}/submissions/draft/package`,
+      fs.readFileSync(zip),
+      {
+        headers: {
+          ...getBaseHeaders({ accessToken }),
+          "Content-Type": "application/zip"
+        }
+      }
+    )
+    .then(({ headers }) => ({ location: headers.location }))
+    .catch(e => ({
+      error: getErrorMessage({
+        zip,
+        error: e.response.data.message,
+        actionName: "upload"
+      })
+    }));
+}
+
+async function loopProgress({
+  accessToken,
+  productId,
+  location,
+  zip
+}: {
+  accessToken: string;
+  productId: string;
+  location: string;
+  zip: string;
+}): Promise<{ error?: string }> {
+  let data;
+  do {
+    try {
+      ({ data } = await getUploadStatus({
+        accessToken,
+        productID: productId,
+        operationID: location
+      }));
+    } catch (e) {
+      return {
+        error: getErrorMessage({ zip, error: e, actionName: "upload" })
+      };
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 1000));
+  } while (data.status === "InProgress");
+
+  if (data.status === "Failed") {
+    return {
+      error: getErrorMessage({ zip, error: data.status, actionName: "upload" })
+    };
+  }
+  return { error: "" };
+}
+
+async function publish({
+  accessToken,
+  productId,
+  devChangelog,
+  zip
+}: {
+  accessToken: string;
+  productId: string;
+  devChangelog: string;
+  zip: string;
+}): Promise<{ error: string; operationId: string }> {
+  return axios
+    .post(
+      `${baseUrl}/products/${productId}/submissions`,
+      {
+        notes: devChangelog
+      },
+      {
+        headers: getBaseHeaders({ accessToken })
+      }
+    )
+    .then(({ status, data, headers: { location } }) => ({
+      error:
+        status !== STATUS_ACCEPTED
+          ? getErrorMessage({ zip, error: data.status, actionName: "publish" })
+          : "",
+      operationId: location
+    }))
+    .catch(e => ({
+      error: getErrorMessage({
+        zip,
+        error: e.response.data,
+        actionName: "publish"
+      }),
+      operationId: ""
+    }));
+}
+
+async function checkPublishStatus({
+  accessToken,
+  productId,
+  operationId,
+  zip
+}: {
+  accessToken: string;
+  productId: string;
+  operationId: string;
+  zip: string;
+}): Promise<{ error: string }> {
+  return axios
+    .get(
+      `${baseUrl}/products/${productId}/submissions/operations/${operationId}`,
+      {
+        headers: getBaseHeaders({ accessToken })
+      }
+    )
+    .then(({ data }) => ({
+      error:
+        data.status === "Failed"
+          ? getErrorMessage({
+              zip,
+              error: data.message,
+              actionName: "publish"
+            })
+          : ""
+    }));
+}
+
+export async function deployToEdgePublishApi({
+  productId,
+  clientId,
+  clientSecret,
+  accessTokenUrl,
+  accessToken,
+  zip,
+  verbose,
+  devChangelog
+}: EdgeOptionsPublishApi): Promise<true> {
+  return new Promise(async (resolve, reject) => {
+    if (verbose) {
+      console.log(
+        getVerboseMessage({
+          store,
+          message: `Updating ${getExtInfo(
+            zip,
+            "name"
+          )} with product ID ${productId} `
+        })
+      );
+    }
+
+    const { location, error: errorUpload } = await upload({
+      accessToken,
+      zip,
+      productId
+    });
+    if (errorUpload) {
+      if (errorUpload.includes("Invalid JWT")) {
+        const { accessToken } = await getEdgePublishApiAccessToken({
+          clientId,
+          clientSecret,
+          accessTokenUrl
+        });
+        await deployToEdgePublishApi({
+          productId,
+          zip,
+          verbose,
+          devChangelog,
+          accessToken,
+          accessTokenUrl,
+          clientSecret,
+          clientId
+        });
+      } else {
+        reject(errorUpload);
+      }
+      return;
+    }
+
+    const { error: errorProgress } = await loopProgress({
+      accessToken,
+      productId,
+      location,
+      zip
+    });
+    if (errorProgress) {
+      reject(errorProgress);
+      return;
+    }
+
+    if (verbose) {
+      console.log(
+        getVerboseMessage({
+          store,
+          message: `Publishing ${getExtInfo(zip, "name")} version ${getExtInfo(
+            zip,
+            "version"
+          )}`
+        })
+      );
+    }
+
+    const { error: errorPublish, operationId } = await publish({
+      accessToken,
+      productId,
+      devChangelog,
+      zip
+    });
+
+    if (errorPublish) {
+      reject(
+        getErrorMessage({ zip, error: errorPublish, actionName: "publish" })
+      );
+      return;
+    }
+
+    const { error: errorPublishStatus } = await checkPublishStatus({
+      accessToken,
+      productId,
+      operationId,
+      zip
+    });
+
+    if (errorPublishStatus) {
+      reject(errorPublishStatus);
+      return;
+    }
+
+    logSuccessfullyPublished({ store, extId: productId, zip });
+    resolve(true);
+  });
+}

--- a/src/stores/edge/new/edge-deploy.ts
+++ b/src/stores/edge/new/edge-deploy.ts
@@ -12,11 +12,7 @@ const store = "Edge";
 const baseUrl = `https://api.addons.microsoftedge.microsoft.com/v1`;
 const STATUS_ACCEPTED = 202;
 
-function getBaseHeaders({
-  accessToken,
-}: {
-  accessToken: string;
-}): {
+function getBaseHeaders({ accessToken }: { accessToken: string }): {
   Authorization: string;
 } {
   return {

--- a/src/stores/edge/new/edge-input.ts
+++ b/src/stores/edge/new/edge-input.ts
@@ -1,0 +1,113 @@
+import { getCorrectZip, getFullPath, getIsFileExists } from "../../../utils";
+import { deployToEdgePublishApi } from "./edge-deploy";
+
+export class EdgeOptionsPublishApi {
+  /**
+   * The client ID.<br>
+   * To obtain it, follow [these steps](https://github.com/avi12/web-ext-deploy/tree/main/EDGE_CREDENTIALS.md).
+   */
+  clientId: string;
+
+  /**
+   * The client secret.<br>
+   * To obtain it, follow [these steps](https://github.com/avi12/web-ext-deploy/tree/main/EDGE_CREDENTIALS.md).
+   */
+  clientSecret: string;
+
+  /**
+   * The access token URL.<br>
+   * To obtain it, follow [these steps](https://github.com/avi12/web-ext-deploy/tree/main/EDGE_CREDENTIALS.md).
+   */
+  accessTokenUrl: string;
+
+  /**
+   * The access token.<br>
+   * To obtain it, follow [these steps](https://github.com/avi12/web-ext-deploy/tree/main/EDGE_CREDENTIALS.md).
+   */
+  accessToken: string;
+
+  /** The extension ID. E.g. `https://partner.microsoft.com/en-us/dashboard/microsoftedge/EXT_ID` */
+  productId: string;
+
+  /**
+   * The path to the ZIP, relative from the current working directory (`process.cwd()`)<br>
+   * You can use `{version}`, which will be replaced by the `version` entry from your `package.json`, e.g. `some-zip-v{version}.zip`
+   */
+  zip: string;
+
+  /**
+   * A description of the technical changes made in this version, compared to the previous one.<br>
+   * This will only be seen by the Edge Extensions reviewers.<br>
+   * It's recommended to use instead `--edge-dev-changelog` , so it stays up to date.
+   */
+  devChangelog?: string;
+
+  /** If `true`, every step of uploading to the Edge Add-ons will be logged to the console. */
+  verbose?: boolean;
+
+  constructor(options: EdgeOptionsPublishApi) {
+    if (!options.productId) {
+      throw new Error(
+        getErrorMessage(
+          "No product ID is provided, e.g. https://partner.microsoft.com/en-us/dashboard/microsoftedge/PRODUCT_ID"
+        )
+      );
+    }
+
+    const messageObtain =
+      "To obtain one, follow https://github.com/avi12/web-ext-deploy/tree/main/EDGE_CREDENTIALS.md";
+
+    if (!options.clientId) {
+      throw new Error(
+        getErrorMessage(`No client ID is provided. ${messageObtain}`)
+      );
+    }
+
+    if (!options.clientSecret) {
+      throw new Error(
+        getErrorMessage(`No client secret is provided. ${messageObtain}`)
+      );
+    }
+
+    if (!options.accessTokenUrl) {
+      throw new Error(
+        getErrorMessage(`No access token URL is provided. ${messageObtain}`)
+      );
+    }
+
+    if (!options.accessToken) {
+      throw new Error(
+        getErrorMessage(`No access token is provided. ${messageObtain}`)
+      );
+    }
+
+    // Zip checking
+    if (!options.zip) {
+      throw new Error(getErrorMessage("No zip is provided"));
+    }
+
+    if (!getIsFileExists(options.zip)) {
+      throw new Error(
+        getErrorMessage(`Zip doesn't exist: ${getFullPath(options.zip)}`)
+      );
+    }
+  }
+}
+
+function getErrorMessage(message: string): string {
+  return `Edge: ${message}`;
+}
+
+export async function prepareToDeployEdgePublishApi(
+  options: EdgeOptionsPublishApi
+): Promise<boolean> {
+  options.zip = getCorrectZip(options.zip);
+
+  if (options.devChangelog) {
+    options.devChangelog = options.devChangelog.replace(/\/\n/g, "\n");
+  }
+
+  // Validate the options
+  new EdgeOptionsPublishApi(options);
+  return deployToEdgePublishApi(options);
+}

--- a/src/stores/edge/new/edge-input.ts
+++ b/src/stores/edge/new/edge-input.ts
@@ -4,25 +4,25 @@ import { deployToEdgePublishApi } from "./edge-deploy";
 export class EdgeOptionsPublishApi {
   /**
    * The client ID.<br>
-   * To obtain it, follow [these steps](https://github.com/avi12/web-ext-deploy/tree/main/EDGE_CREDENTIALS.md).
+   * To obtain it, follow [these steps](https://github.com/avi12/web-ext-deploy/blob/main/EDGE_PUBLISH_API.md).
    */
   clientId: string;
 
   /**
    * The client secret.<br>
-   * To obtain it, follow [these steps](https://github.com/avi12/web-ext-deploy/tree/main/EDGE_CREDENTIALS.md).
+   * To obtain it, follow [these steps](https://github.com/avi12/web-ext-deploy/blob/main/EDGE_PUBLISH_API.md).
    */
   clientSecret: string;
 
   /**
    * The access token URL.<br>
-   * To obtain it, follow [these steps](https://github.com/avi12/web-ext-deploy/tree/main/EDGE_CREDENTIALS.md).
+   * To obtain it, follow [these steps](https://github.com/avi12/web-ext-deploy/blob/main/EDGE_PUBLISH_API.md).
    */
   accessTokenUrl: string;
 
   /**
    * The access token.<br>
-   * To obtain it, follow [these steps](https://github.com/avi12/web-ext-deploy/tree/main/EDGE_CREDENTIALS.md).
+   * To obtain it, follow [these steps](https://github.com/avi12/web-ext-deploy/blob/main/EDGE_PUBLISH_API.md).
    */
   accessToken: string;
 
@@ -55,7 +55,7 @@ export class EdgeOptionsPublishApi {
     }
 
     const messageObtain =
-      "To obtain one, follow https://github.com/avi12/web-ext-deploy/tree/main/EDGE_CREDENTIALS.md";
+      "To obtain one, follow https://github.com/avi12/web-ext-deploy/blob/main/EDGE_PUBLISH_API.md";
 
     if (!options.clientId) {
       throw new Error(

--- a/src/stores/edge/old/edge-deploy-old.ts
+++ b/src/stores/edge/old/edge-deploy-old.ts
@@ -1,13 +1,13 @@
 import puppeteer, { Page } from "puppeteer";
 import duration from "parse-duration";
-import { EdgeOptions } from "./edge-input";
+import { EdgeOptions } from "./edge-input-old";
 import {
   disableImages,
   getExistingElementSelector,
   getExtInfo,
   getVerboseMessage,
   logSuccessfullyPublished
-} from "../../utils";
+} from "../../../utils";
 import { compare } from "compare-versions";
 
 const store = "Edge";

--- a/src/stores/edge/old/edge-input-old.ts
+++ b/src/stores/edge/old/edge-input-old.ts
@@ -72,7 +72,7 @@ export async function prepareToDeployEdge(
 
   console.log(
     getErrorMessage(
-      "The old cookie-based deployment is deprecated. Please use the new Edge Publish API: https://github.com/avi12/web-ext-deploy/tree/main/EDGE_PUBLISH_API.md"
+      "The old cookie-based deployment is deprecated. Please use the new Edge Publish API: https://github.com/avi12/web-ext-deploy/blob/main/EDGE_PUBLISH_API.md"
     )
   );
 

--- a/src/stores/edge/old/edge-input-old.ts
+++ b/src/stores/edge/old/edge-input-old.ts
@@ -1,6 +1,9 @@
-import { getCorrectZip, getFullPath, getIsFileExists } from "../../utils";
-import { deployToEdge } from "./edge-deploy";
+import { getCorrectZip, getFullPath, getIsFileExists } from "../../../utils";
+import { deployToEdge } from "./edge-deploy-old";
 
+/**
+ * @deprecated Use `EdgeOptionsPublishApi` instead
+ */
 export class EdgeOptions {
   /** The cookie required to login to the publisher's account, called: `.AspNet.Cookies`<br>
    * If you have a hard time obtaining it, run: `--get-cookies=edge` */
@@ -25,14 +28,20 @@ export class EdgeOptions {
   /** If `true`, every step of uploading to the Edge Add-ons will be logged to the console. */
   verbose?: boolean;
 
-  constructor(options) {
+  constructor(options: EdgeOptions) {
     if (!options.extId) {
-      throw new Error(getErrorMessage("No extension ID is provided, e.g. https://partner.microsoft.com/en-us/dashboard/microsoftedge/EXT_ID"));
+      throw new Error(
+        getErrorMessage(
+          "No extension ID is provided, e.g. https://partner.microsoft.com/en-us/dashboard/microsoftedge/EXT_ID"
+        )
+      );
     }
 
     if (!options.cookie) {
-      throw new Error(getErrorMessage(`No cookie is provided. The cookie's name is ".AspNet.Cookies". If you have a hard time obtaining it, run:
-web-ext-deploy --get-cookies=edge`));
+      throw new Error(
+        getErrorMessage(`No cookie is provided. The cookie's name is ".AspNet.Cookies". If you have a hard time obtaining it, run:
+web-ext-deploy --get-cookies=edge`)
+      );
     }
 
     // Zip checking
@@ -45,7 +54,6 @@ web-ext-deploy --get-cookies=edge`));
         getErrorMessage(`Zip doesn't exist: ${getFullPath(options.zip)}`)
       );
     }
-
   }
 }
 
@@ -62,8 +70,13 @@ export async function prepareToDeployEdge(
     options.devChangelog = options.devChangelog.replace(/\/\/n/g, "\n");
   }
 
+  console.log(
+    getErrorMessage(
+      "The old cookie-based deployment is deprecated. Please use the new Edge Publish API: https://github.com/avi12/web-ext-deploy/tree/main/EDGE_PUBLISH_API.md"
+    )
+  );
+
   // Validate the options
   new EdgeOptions(options);
   return deployToEdge(options);
 }
-

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,1 @@
+export const Stores = ["chrome", "firefox", "edge", "opera"] as const;


### PR DESCRIPTION
Close #28

# How to use
## Generate an access token
1. Retreive `client_id`, `client_secret`, `acecss_token_url` from the [Publish API](https://partner.microsoft.com/en-us/dashboard/microsoftedge/publishapi) page
2. ```powershell
   web-ext-deploy --edge-client-id="client_id" --edge-client-secret="client_secret" --edge-access-token-url="access_token_url"
   ```
3. The `EXT_ID` is now `PRODUCT_ID`

## Usage
edge.env
```env
CLIENT_ID="ClientID"
CLIENT_SECRET="ClientSecret"
ACCESS_TOKEN_URL="AccessTokenURL"
ACCESS_TOKEN="AccessToken"
ZIP="dist/some-zip-v{version}.zip"
PRODUCT_ID="ProductID"
```

CLI
```powershell
web-ext-deploy --edge-product-id="ProductID" --edge-access-token="accessToken value" --edge-client-id="clientId" --edge-client-secret="clientSecret" --edge-access-token-url="accessTokenUrl" --edge-zip="dist/some-zip-v{version}.zip" --edge-dev-changelog="Changelog for reviewers\nWith line breaks"
```

Node.js
```js
const { deployEdgePublishApi } = require("web-ext-deploy");

deployEdgePublishApi({
  productId: "PRODUCT_ID",
  clientId: "clientId",
  clientSecret: "clientSecret",
  accessTokenUrl: "accessTokenUrl",
  accessToken: "accessToken",
  zip: "dist/some-zip-v{version}.zip",
  devChangelog: "Changes for reviewers",
  verbose: false
}).catch(console.error);
```